### PR TITLE
Docker improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+Dockerfile
+README.md
+resources/
+.git/
+.github/

--- a/.github/workflows/docker-onpush.yml
+++ b/.github/workflows/docker-onpush.yml
@@ -29,7 +29,7 @@ jobs:
         uses: docker/build-push-action@v2.4.0
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/glob:latest
 

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -28,7 +28,7 @@ jobs:
         uses: docker/build-push-action@v2.4.0
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64,linux/386,linux/arm64,linux/arm/v7,linux/arm/v6
           push: true
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/glob:release
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:latest AS builder
+FROM python:alpine AS builder
 
-RUN apk add python3 py3-pip py3-virtualenv gcc make musl-dev python3-dev libffi-dev
+RUN apk add gcc make musl-dev libffi-dev
 
 WORKDIR /GLOB
 COPY . .
@@ -9,8 +9,8 @@ RUN python3 -m venv env
 RUN source env/bin/activate && pip3 install -r requirements.txt
 
 
-FROM alpine:latest
-RUN apk add python3 py3-virtualenv ffmpeg
+FROM python:alpine AS runner
+RUN apk add ffmpeg
 
 COPY --from=builder /GLOB /GLOB
 WORKDIR /GLOB


### PR DESCRIPTION
 * Switched to `python:alpine` as the base image, meaning it now uses Python 3.9.4
 * Added a `.dockerignore` file
 * Enabled building for `linux/386`